### PR TITLE
Additive Alt Drag

### DIFF
--- a/addons/cyclops_level_builder/tools/tool_block.gd
+++ b/addons/cyclops_level_builder/tools/tool_block.gd
@@ -312,10 +312,10 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 		elif tool_state == ToolState.MOVE_BLOCK:
 			if e.alt_pressed:
 #				block_drag_cur = MathUtil.closest_point_on_line(origin_local, dir_local, block_drag_p0_local, drag_floor_normal)
-				block_drag_cur = MathUtil.closest_point_on_line(origin_local, dir_local, block_drag_p0_local, Vector3.UP)
+				block_drag_cur = MathUtil.closest_point_on_line(origin_local, dir_local, block_drag_cur, Vector3.UP)
 			else:
 #				block_drag_cur = MathUtil.intersect_plane(origin_local, dir_local, block_drag_p0_local, drag_floor_normal)
-				block_drag_cur = MathUtil.intersect_plane(origin_local, dir_local, block_drag_p0_local, Vector3.UP)
+				block_drag_cur = MathUtil.intersect_plane(origin_local, dir_local, block_drag_cur, Vector3.UP)
 			
 			var grid_step_size:float = pow(2, builder.get_global_scene().grid_size)
 			block_drag_cur = MathUtil.snap_to_grid(block_drag_cur, grid_step_size)

--- a/addons/cyclops_level_builder/tools/tool_edit_edge.gd
+++ b/addons/cyclops_level_builder/tools/tool_edit_edge.gd
@@ -35,6 +35,7 @@ var tool_state:ToolState = ToolState.NONE
 var drag_handle:HandleEdge
 var drag_mouse_start_pos:Vector2
 var drag_handle_start_pos:Vector3
+var drag_handle_int:Vector3
 			
 var tracked_blocks_root:CyclopsBlocks
 
@@ -268,6 +269,7 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 					drag_handle = handle
 #					drag_handle_start_pos = handle.p_ref
 					drag_handle_start_pos = res.position
+					drag_handle_int = drag_handle_start_pos
 					tool_state = ToolState.DRAGGING
 
 					cmd_move_edge = CommandMoveEdges.new()
@@ -302,9 +304,10 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 			
 			var drag_to:Vector3
 			if e.alt_pressed:
-				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_int, Vector3.UP)
 			else:
-				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_int, Vector3.UP)
+			drag_handle_int = drag_to
 			
 			var offset:Vector3 = drag_to - drag_handle_start_pos
 			offset = MathUtil.snap_to_grid(offset, grid_step_size)

--- a/addons/cyclops_level_builder/tools/tool_edit_face.gd
+++ b/addons/cyclops_level_builder/tools/tool_edit_face.gd
@@ -35,6 +35,7 @@ var tool_state:ToolState = ToolState.NONE
 var drag_handle:HandleFace
 var drag_mouse_start_pos:Vector2
 var drag_handle_start_pos:Vector3
+var drag_handle_int:Vector3
 			
 var tracked_blocks_root:CyclopsBlocks
 
@@ -290,6 +291,7 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 					drag_handle = handle
 #					drag_handle_start_pos = handle.p_ref
 					drag_handle_start_pos = res.position
+					drag_handle_int = drag_handle_start_pos
 					tool_state = ToolState.DRAGGING
 
 					cmd_move_face = CommandMoveFaces.new()
@@ -322,9 +324,10 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 			
 			var drag_to:Vector3
 			if e.alt_pressed:
-				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_int, Vector3.UP)
 			else:
-				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_int, Vector3.UP)
+			drag_handle_int = drag_to
 			
 			var offset = drag_to - drag_handle_start_pos
 			offset = MathUtil.snap_to_grid(offset, grid_step_size)

--- a/addons/cyclops_level_builder/tools/tool_edit_vertex.gd
+++ b/addons/cyclops_level_builder/tools/tool_edit_vertex.gd
@@ -37,6 +37,7 @@ var tool_state:ToolState = ToolState.NONE
 var drag_handle:HandleVertex
 var drag_mouse_start_pos:Vector2
 var drag_handle_start_pos:Vector3
+var drag_handle_int:Vector3
 var added_point_pos:Vector3
 
 var cmd_move_vertex:CommandMoveVertices
@@ -238,6 +239,7 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 				if handle:
 					drag_handle = handle
 					drag_handle_start_pos = handle.position
+					drag_handle_int = drag_handle_start_pos
 					tool_state = ToolState.DRAGGING
 
 					cmd_move_vertex = CommandMoveVertices.new()
@@ -267,6 +269,7 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 						if result:
 							#print("start drag add")
 							drag_handle_start_pos = result.position
+							drag_handle_int = drag_handle_start_pos
 							added_point_pos = result.position
 							tool_state = ToolState.DRAGGING_ADD
 
@@ -291,9 +294,10 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 			
 			var drag_to:Vector3
 			if e.alt_pressed:
-				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_int, Vector3.UP)
 			else:
-				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_int, Vector3.UP)
+			drag_handle_int = drag_to
 			
 			drag_to = MathUtil.snap_to_grid(drag_to, grid_step_size)
 			drag_handle.position = drag_to
@@ -316,9 +320,10 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 			
 			var drag_to:Vector3
 			if e.alt_pressed:
-				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.closest_point_on_line(origin_local, dir_local, drag_handle_int, Vector3.UP)
 			else:
-				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_start_pos, Vector3.UP)
+				drag_to = MathUtil.intersect_plane(origin_local, dir_local, drag_handle_int, Vector3.UP)
+			drag_handle_int = drag_to
 
 			drag_to = MathUtil.snap_to_grid(drag_to, grid_step_size)
 			


### PR DESCRIPTION
Addresses #9 

By tracking an intermediate state of the drag handle position and using that instead of the starting drag position, Alt dragging becomes additive (that is, beginning to hold Alt in the middle of a drag allows moving a drag handle along the Y axis at its _current position_, as opposed to the position it started at).

While technically this makes the `drag_handle_start_pos` field redundant (currently used only to set the initial state of the intermediary handle), I left that field alone just in case it will be used in the future.