### PR TITLE
Update dock_material.md

### DIFF
--- a/doc/dock_material.md
+++ b/doc/dock_material.md
@@ -1,8 +1,10 @@
 # Material Dock
 
+You can obtain materials for your project from [Material Maker](https://github.com/RodZill4/material-maker). Make sure to export to godot and import the resulting files into your project.
+
 The material dock provides a place to view and apply materials to your environment.
 
-Add materials to the material dock by clicking and dragging them from the file system dock.
+Add materials to the material dock by clicking and dragging .tres files from the file system dock.
 
 ![Dragging materials into Material dock](dragging_into_material_dock.gif)
 


### PR DESCRIPTION
Updated documentation to include accepted file types and where this type of file can be obtained from.

I opened an issue [Expand Material Creation Documentation #85](https://github.com/blackears/cyclopsLevelBuilder/issues/85#issue-1909352449) because at the time I did not fully understand how to map textures using this addon, but after some research I found the following information and would like to share it with future users who come across the same issue.

I would not be surprised to find out that there are ways to create materials in godot without material maker, but I'm very new to godot in general and this is just what I was able to find.