### PR TITLE
Rename Logger to CyclopsLogger and Levels to LogLevels to fix #122

### DIFF
--- a/godot/addons/cyclops_level_builder/cyclops_level_builder.gd
+++ b/godot/addons/cyclops_level_builder/cyclops_level_builder.gd
@@ -34,7 +34,7 @@ const CYCLOPS_HUD_NAME = "CyclopsGlobalHud"
 
 var config:CyclopsConfig = preload("res://addons/cyclops_level_builder/data/configuration.tres")
 
-var logger:Logger = Logger.new()
+var logger:CyclopsLogger = CyclopsLogger.new()
 
 var material_dock:MaterialPaletteViewport
 var convex_face_editor_dock:ConvexFaceEdtiorViewport
@@ -178,7 +178,7 @@ func _exit_tree():
 		remove_control_from_docks(cyclops_console_dock)
 		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, editor_toolbar)
 
-	if upgrade_cyclops_blocks_toolbar.activated:		
+	if upgrade_cyclops_blocks_toolbar.activated:
 		remove_control_from_container(EditorPlugin.CONTAINER_SPATIAL_EDITOR_MENU, upgrade_cyclops_blocks_toolbar)
 
 	material_dock.queue_free()
@@ -189,7 +189,7 @@ func _exit_tree():
 	editor_toolbar.queue_free()
 	upgrade_cyclops_blocks_toolbar.queue_free()
 
-func log(message:String, level:Logger.Level = Logger.Level.ERROR):
+func log(message:String, level:CyclopsLogger.LogLevel = CyclopsLogger.LogLevel.ERROR):
 	logger.log(message, level)
 
 func get_blocks()->Array[CyclopsBlock]:

--- a/godot/addons/cyclops_level_builder/util/logger.gd
+++ b/godot/addons/cyclops_level_builder/util/logger.gd
@@ -25,11 +25,7 @@
 extends RefCounted
 class_name CyclopsLogger
 
-enum LogLevel {
-	ERROR,
-	WARNING,
-	INFO
-	}
+enum LogLevel { ERROR, WARNING, INFO }
 
 func log(message:String, level:LogLevel = LogLevel.ERROR):
 	print(message)

--- a/godot/addons/cyclops_level_builder/util/logger.gd
+++ b/godot/addons/cyclops_level_builder/util/logger.gd
@@ -23,9 +23,13 @@
 
 @tool
 extends RefCounted
-class_name Logger
+class_name CyclopsLogger
 
-enum Level { ERROR, WARNING, INFO }
+enum LogLevel {
+	ERROR,
+	WARNING,
+	INFO
+	}
 
-func log(message:String, level:Level = Level.ERROR):
+func log(message:String, level:LogLevel = LogLevel.ERROR):
 	print(message)

--- a/godot/addons/gut/utils.gd
+++ b/godot/addons/gut/utils.gd
@@ -269,10 +269,10 @@ func is_godot_version_gte(expected, engine_info=Engine.get_version_info()):
 # ------------------------------------------------------------------------------
 func get_logger():
 	if(_test_mode):
-		return Logger.new()
+		return CyclopsLogger.new()
 	else:
 		if(_lgr == null):
-			_lgr = Logger.new()
+			_lgr = CyclopsLogger.new()
 		return _lgr
 
 


### PR DESCRIPTION
As far as I can tell, this class is only used a few times and I updated the names in those places. Also removed two wrongly placed tabs.