### PR TITLE
Add reset UV mode to material brush tool

### DIFF
--- a/godot/addons/cyclops_level_builder/tools/tool_material_brush.gd
+++ b/godot/addons/cyclops_level_builder/tools/tool_material_brush.gd
@@ -49,43 +49,45 @@ func _get_tool_properties_editor()->Control:
 	var ed:ToolMaterialBrushSettingsEditor = preload("res://addons/cyclops_level_builder/tools/tool_material_brush_settings_editor.tscn").instantiate()
 
 	ed.settings = settings
-	
+
 	return ed
-	
-func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:	
+
+func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 	if event is InputEventMouseButton:
-		
+
 		var e:InputEventMouseButton = event
 		if e.button_index == MOUSE_BUTTON_LEFT:
 
 			if e.is_pressed():
-				
+
 				if tool_state == ToolState.READY:
 					var origin:Vector3 = viewport_camera.project_ray_origin(e.position)
-					var dir:Vector3 = viewport_camera.project_ray_normal(e.position)				
-					
+					var dir:Vector3 = viewport_camera.project_ray_normal(e.position)
+
 					var result:IntersectResults = builder.intersect_ray_closest(origin, dir)
-					
+
 					if result:
 						cmd = CommandSetMaterial.new()
 						cmd.builder = builder
-						
+
 						cmd.setting_material = settings.paint_materials
 						cmd.material_path = builder.tool_material_path if !settings.erase_material else ""
-						
+
 						cmd.setting_color = settings.paint_color
 						cmd.color = settings.color
-						
+
 						cmd.setting_visibility = settings.paint_visibility
 						cmd.visibility = settings.visibility
-						
+
+						cmd.resetting_uv = settings.reset_uv
+
 						var block:CyclopsBlock = result.object
 						if settings.individual_faces:
 							cmd.add_target(block.get_path(), [result.face_index])
 
 						else:
 							cmd.add_target(block.get_path(), block.control_mesh.get_face_indices())
-						
+
 						tool_state = ToolState.PAINTING
 
 			else:
@@ -93,23 +95,23 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 					cmd.undo_it()
 					if cmd.will_change_anything():
 						var undo:EditorUndoRedoManager = builder.get_undo_redo()
-						cmd.add_to_undo_manager(undo)					
-					
+						cmd.add_to_undo_manager(undo)
+
 					tool_state = ToolState.READY
-					
+
 			return true
-		
-				
+
+
 	elif event is InputEventMouseMotion:
-		
+
 		var e:InputEventMouseMotion = event
 
 		if tool_state == ToolState.PAINTING:
 			var origin:Vector3 = viewport_camera.project_ray_origin(e.position)
-			var dir:Vector3 = viewport_camera.project_ray_normal(e.position)				
-			
+			var dir:Vector3 = viewport_camera.project_ray_normal(e.position)
+
 			var result:IntersectResults = builder.intersect_ray_closest(origin, dir)
-			
+
 			if result:
 				print ("hit ", result.object.name)
 				cmd.undo_it()
@@ -120,12 +122,12 @@ func _gui_input(viewport_camera:Camera3D, event:InputEvent)->bool:
 				else:
 					cmd.add_target(block.get_path(), block.control_mesh.get_face_indices())
 				cmd.do_it()
-			
+
 			return true
-		
+
 	return false
 
-	
+
 
 func _activate(builder:CyclopsLevelBuilder):
 	super._activate(builder)
@@ -136,5 +138,5 @@ func _activate(builder:CyclopsLevelBuilder):
 func _deactivate():
 	var cache:Dictionary = settings.save_to_cache()
 	builder.set_tool_cache(TOOL_ID, cache)
-	
-	
+
+

--- a/godot/addons/cyclops_level_builder/tools/tool_material_brush_settings.gd
+++ b/godot/addons/cyclops_level_builder/tools/tool_material_brush_settings.gd
@@ -28,6 +28,7 @@ class_name ToolMaterialBrushSettings
 @export var paint_materials:bool = true
 @export var paint_color:bool = false
 @export var paint_visibility:bool = false
+@export var reset_uv:bool = false
 
 
 @export var individual_faces:bool = false
@@ -45,7 +46,8 @@ func load_from_cache(cache:Dictionary):
 	erase_material = cache.get("erase_material", false)
 	color = cache.get("color", Color.WHITE)
 	visibility = cache.get("visibility", false)
-	
+	reset_uv = cache.get("reset_uv", false)
+
 func save_to_cache():
 	return {
 		"paint_materials": paint_materials,
@@ -55,6 +57,7 @@ func save_to_cache():
 		"erase_material": erase_material,
 		"color": color,
 		"visibility": visibility,
+		"reset_uv": reset_uv,
 	}
 
 

--- a/godot/addons/cyclops_level_builder/tools/tool_material_brush_settings_editor.gd
+++ b/godot/addons/cyclops_level_builder/tools/tool_material_brush_settings_editor.gd
@@ -43,16 +43,18 @@ func update():
 
 		%check_paint_visibility.disabled = true
 		%check_visibility.disabled = true
-		
+
+		%check_reset_uv.disabled = true
+
 		return
-		
+
 	%check_paint_material.disabled = false
 	%check_paint_color.disabled = false
 	%check_paint_visibility.disabled = false
 	%check_individual_faces.disabled = false
 
 	%check_individual_faces.button_pressed = settings.individual_faces
-	
+
 	%check_paint_material.button_pressed = settings.paint_materials
 	%check_erase_material.button_pressed = settings.erase_material
 	%check_erase_material.disabled = !settings.paint_materials
@@ -60,12 +62,12 @@ func update():
 	%check_paint_color.button_pressed = settings.paint_color
 	%color_button.color = settings.color
 	%color_button.disabled = !settings.paint_color
-	
+
 	%check_paint_visibility.button_pressed = settings.paint_visibility
 	%check_visibility.button_pressed = settings.visibility
 	%check_visibility.disabled = !settings.paint_visibility
-	
-	
+
+	%check_reset_uv.button_pressed = settings.reset_uv
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -107,3 +109,6 @@ func _on_check_paint_visibility_toggled(button_pressed:bool):
 func _on_check_visibility_toggled(button_pressed:bool):
 	settings.visibility = button_pressed
 
+
+func _on_check_reset_uv_toggled(button_pressed:bool):
+	settings.reset_uv = button_pressed

--- a/godot/addons/cyclops_level_builder/tools/tool_material_brush_settings_editor.tscn
+++ b/godot/addons/cyclops_level_builder/tools/tool_material_brush_settings_editor.tscn
@@ -67,6 +67,11 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Visible"
 
+[node name="check_reset_uv" type="CheckBox" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Reset UV"
+
 [connection signal="toggled" from="VBoxContainer/check_individual_faces" to="." method="_on_check_individual_faces_toggled"]
 [connection signal="toggled" from="VBoxContainer/check_paint_material" to="." method="_on_check_paint_material_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer/VBoxContainer/check_erase_material" to="." method="_on_check_erase_material_toggled"]
@@ -74,3 +79,4 @@ text = "Visible"
 [connection signal="color_changed" from="VBoxContainer/MarginContainer2/HBoxContainer/color_button" to="." method="_on_color_button_color_changed"]
 [connection signal="toggled" from="VBoxContainer/check_paint_visibility" to="." method="_on_check_paint_visibility_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer3/check_visibility" to="." method="_on_check_visibility_toggled"]
+[connection signal="toggled" from="VBoxContainer/check_reset_uv" to="." method="_on_check_reset_uv_toggled"]


### PR DESCRIPTION
I didn't find an easy way to reset the UV coordinates back to the default world alignment, so I implemented a setting in the material brush tool to do this.

Please merge or use as inspiration if you think this is a valid improvement.

Sorry about the whitespace changes, I had the editor set to autoremove stray tabs etc. I can fix those back manually, if you prefer to keep the extra tabs :)
