### PR TITLE
Implement Fix for #214

### DIFF
--- a/godot/addons/cyclops_level_builder/commands/mesh/cmd_move_face_planar.gd
+++ b/godot/addons/cyclops_level_builder/commands/mesh/cmd_move_face_planar.gd
@@ -51,7 +51,7 @@ func move_to(offset:Vector3, intermediate:bool):
 		var block:CyclopsBlock = builder.get_node(block_path)
 		
 		block_name = block.name
-		block_selected = block.selected
+		#block_selected = block.selected
 		tracked_block_data = block.mesh_vector_data
 	
 	var ctl_mesh:ConvexVolume = ConvexVolume.new()
@@ -93,10 +93,9 @@ func undo_it():
 		block.owner = builder.get_editor_interface().get_edited_scene_root()
 		block.mesh_vector_data = tracked_block_data
 		block.name = block_name
-		block.selected = block_selected
+		#block.selected = block_selected
 		
 		deleted = false
 		return
 	
 	move_to(Vector3.ZERO, false)
-

--- a/godot/addons/cyclops_level_builder/tools/tool_block.gd
+++ b/godot/addons/cyclops_level_builder/tools/tool_block.gd
@@ -112,7 +112,7 @@ func start_block_drag(viewport_camera:Camera3D, event:InputEvent):
 			cmd_move_face.block_path = result.object.get_path()
 			cmd_move_face.face_index = result.face_index
 			cmd_move_face.lock_uvs = builder.lock_uvs
-			cmd_move_face.move_dir_normal = result.object.control_mesh.faces[result.face_id].normal
+			cmd_move_face.move_dir_normal = result.object.control_mesh.faces[result.face_index].normal
 
 			move_face_origin = result.object.global_transform * result.position
 			#print("moving face move_face_origin %s" % move_face_origin)


### PR DESCRIPTION
Fixes #214.
tool_block was using a deprecated "result.face_id" instead of the "result.face_index"
cmd_move_face_planar was using block_selected, which is not in the definitions for CyclopsBlock
May have broken something else. Not sure.
If it does break something else, then the likely culprit is cmd_move_face_planar.gd
