### PR TITLE
Fix: Prevent zero vector normalization warning in convex_volume.gd

### DIFF
--- a/godot/addons/cyclops_level_builder/math/convex_volume.gd
+++ b/godot/addons/cyclops_level_builder/math/convex_volume.gd
@@ -1585,8 +1585,10 @@ func create_mesh(material_list:Array[Material], default_material:Material, overr
 			var r:float = 1.0 / (duv1.x * duv2.y - duv2.x * duv1.y)
 			var t:Vector3 = (e1 * duv2.y - e2 * duv1.y) * r
 			var b:Vector3 = (e2 * duv1.x - e1 * duv2.x) * r
-			
-			t = t.normalized()
+
+			#t = t.normalized()
+			if t.is_zero_approx():
+				t = t.normalized()
 			
 			for j in 3:
 				tangents.append(t.x)


### PR DESCRIPTION
When generating meshes from degenerate geometry (e.g., blocks with zero scale or overlapping vertices), the calculated normal vector can sometimes be `Vector3(0, 0, 0)`. 

This commit adds a check using `is_zero_approx()` before normalization in `create_mesh()` to safely handle these edge cases, returning `Vector3.ZERO` without spamming the debugger or console.

Before
<img width="1203" height="655" alt="grafik" src="https://github.com/user-attachments/assets/58073688-0f4e-4b48-a94c-e797e1ebd55e" />
After:
<img width="1200" height="620" alt="grafik" src="https://github.com/user-attachments/assets/9c2a9868-968a-46cf-a3d6-4119c1e8ea31" />
